### PR TITLE
Fixing tests

### DIFF
--- a/cinema-backend/.gitignore
+++ b/cinema-backend/.gitignore
@@ -38,5 +38,5 @@ out/
 
 #JMH trash:
 src/test/generated_tests/
-jmh_wyniki.json
-jmh_wyniki/
+jmh_wyniki/*
+!jmh_wyniki/.gitkeep

--- a/cinema-backend/build.gradle
+++ b/cinema-backend/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 
     testImplementation 'org.openjdk.jmh:jmh-core:1.33'
     testAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.33'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     implementation "org.mapstruct:mapstruct:${mapstructVer}"
     annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVer}"

--- a/cinema-backend/src/main/java/pl/edu/pw/ee/cinemabackend/config/selenium/SeleniumWebDriverConfig.java
+++ b/cinema-backend/src/main/java/pl/edu/pw/ee/cinemabackend/config/selenium/SeleniumWebDriverConfig.java
@@ -1,8 +1,6 @@
 package pl.edu.pw.ee.cinemabackend.config.selenium;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
-import org.openqa.selenium.JavascriptException;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -18,7 +16,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 @Configuration
-public class WebDriverConfig {
+public class SeleniumWebDriverConfig {
 
     @Value("chrome,firefox,edge,opera,safari")
     private List<String> browsers;

--- a/cinema-backend/src/main/java/pl/edu/pw/ee/cinemabackend/config/selenium/SeleniumWebDriverConfig.java
+++ b/cinema-backend/src/main/java/pl/edu/pw/ee/cinemabackend/config/selenium/SeleniumWebDriverConfig.java
@@ -53,9 +53,12 @@ public class SeleniumWebDriverConfig {
             default -> {
                 WebDriverManager.firefoxdriver()
                         .setup();
-                yield new FirefoxDriver(new FirefoxOptions() {{
-                    setBinary(Path.of("/usr/bin/firefox"));
-                }});
+                if(String.valueOf(System.getProperty("os.name")).toLowerCase().contains("linux")) {
+                    yield new FirefoxDriver(new FirefoxOptions() {{
+                        setBinary(Path.of("/usr/bin/firefox"));
+                    }});
+                }
+                yield new FirefoxDriver();
             }
         };
         driver.manage()

--- a/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/HomePageSeleniumTests.java
+++ b/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/HomePageSeleniumTests.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import pl.edu.pw.ee.cinemabackend.config.selenium.WebDriverConfig;
+import pl.edu.pw.ee.cinemabackend.config.selenium.SeleniumWebDriverConfig;
 import pl.edu.pw.ee.cinemabackend.pages.HomePage;
 import pl.edu.pw.ee.cinemabackend.pages.LoginPage;
 
@@ -30,13 +30,13 @@ class HomePageSeleniumTests {
     @Value("${browser}")
     private String browser;
     @Autowired
-    private WebDriverConfig webDriverConfig;
+    private SeleniumWebDriverConfig seleniumWebDriverConfig;
     private HomePage homePage;
     private WebDriver driver;
 
     @BeforeEach
     final void setup() {
-        driver = webDriverConfig.setUpWebDriver(browser);
+        driver = seleniumWebDriverConfig.setUpWebDriver(browser);
         driver.get(LOGIN_URL);
         LoginPage loginPage = new LoginPage(driver);
         signIn(loginPage);

--- a/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/LoginPageSeleniumTests.java
+++ b/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/LoginPageSeleniumTests.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import pl.edu.pw.ee.cinemabackend.config.selenium.WebDriverConfig;
+import pl.edu.pw.ee.cinemabackend.config.selenium.SeleniumWebDriverConfig;
 import pl.edu.pw.ee.cinemabackend.pages.LoginPage;
 
 import java.time.Duration;
@@ -29,13 +29,13 @@ class LoginPageSeleniumTests {
     @Value("${browser}")
     private String browser;
     @Autowired
-    private WebDriverConfig webDriverConfig;
+    private SeleniumWebDriverConfig seleniumWebDriverConfig;
     private LoginPage loginPage;
     private WebDriver driver;
 
     @BeforeEach
     final void setup() {
-        driver = webDriverConfig.setUpWebDriver(browser);
+        driver = seleniumWebDriverConfig.setUpWebDriver(browser);
         driver.get(LOGIN_URL);
         loginPage = new LoginPage(driver);
     }

--- a/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/MovieDetailsSeleniumTests.java
+++ b/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/MovieDetailsSeleniumTests.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import pl.edu.pw.ee.cinemabackend.config.selenium.WebDriverConfig;
+import pl.edu.pw.ee.cinemabackend.config.selenium.SeleniumWebDriverConfig;
 import pl.edu.pw.ee.cinemabackend.pages.LoginPage;
 import pl.edu.pw.ee.cinemabackend.pages.MovieDetailsPage;
 
@@ -30,13 +30,13 @@ class MovieDetailsSeleniumTests {
     @Value("${browser}")
     private String browser;
     @Autowired
-    private WebDriverConfig webDriverConfig;
+    private SeleniumWebDriverConfig seleniumWebDriverConfig;
     private MovieDetailsPage movieDetailsPage;
     private WebDriver driver;
 
     @BeforeEach
     final void setup() {
-        driver = webDriverConfig.setUpWebDriver(browser);
+        driver = seleniumWebDriverConfig.setUpWebDriver(browser);
         driver.get(LOGIN_URL);
         LoginPage loginPage = new LoginPage(driver);
         signIn(loginPage);

--- a/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/MoviesPageSeleniumTests.java
+++ b/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/MoviesPageSeleniumTests.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import pl.edu.pw.ee.cinemabackend.config.selenium.WebDriverConfig;
+import pl.edu.pw.ee.cinemabackend.config.selenium.SeleniumWebDriverConfig;
 import pl.edu.pw.ee.cinemabackend.pages.LoginPage;
 import pl.edu.pw.ee.cinemabackend.pages.MoviesPage;
 
@@ -34,14 +34,14 @@ class MoviesPageSeleniumTests {
     @Value("${browser}")
     private String browser;
     @Autowired
-    private WebDriverConfig webDriverConfig;
+    private SeleniumWebDriverConfig seleniumWebDriverConfig;
     private MoviesPage moviesPage;
     private WebDriver driver;
     private final Pattern pattern = Pattern.compile("\\d+");
 
     @BeforeEach
     final void setup() {
-        driver = webDriverConfig.setUpWebDriver(browser);
+        driver = seleniumWebDriverConfig.setUpWebDriver(browser);
         driver.get(LOGIN_URL);
         LoginPage loginPage = new LoginPage(driver);
         signIn(loginPage);

--- a/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/RegisterPageSeleniumTests.java
+++ b/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/RegisterPageSeleniumTests.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import pl.edu.pw.ee.cinemabackend.config.selenium.WebDriverConfig;
+import pl.edu.pw.ee.cinemabackend.config.selenium.SeleniumWebDriverConfig;
 import pl.edu.pw.ee.cinemabackend.pages.RegisterPage;
 
 import java.time.Duration;
@@ -29,13 +29,13 @@ class RegisterPageSeleniumTests {
     @Value("${browser}")
     private String browser;
     @Autowired
-    private WebDriverConfig webDriverConfig;
+    private SeleniumWebDriverConfig seleniumWebDriverConfig;
     private RegisterPage registerPage;
     private WebDriver driver;
 
     @BeforeEach
     final void setup() {
-        driver = webDriverConfig.setUpWebDriver(browser);
+        driver = seleniumWebDriverConfig.setUpWebDriver(browser);
         driver.get(REGISTER_URL);
         registerPage = new RegisterPage(driver);
     }


### PR DESCRIPTION
Benchmarki przestały działać (przynajmniej u mnie) po merge'u Selenium, przez kolizję nazwy klasy `WebDriverConfig` z jakąś wewnątrzną klasą springa. Nadanie innej nazwy dla tej klasy naprawiło ten błąd.
Nadpisywanie ścieżki do binarki firefoxa powinno być teraz wykonywane tylko na linuxie