### PR TITLE
Cypress tests

### DIFF
--- a/cinema-backend/.gitignore
+++ b/cinema-backend/.gitignore
@@ -38,5 +38,5 @@ out/
 
 #JMH trash:
 src/test/generated_tests/
-jmh_wyniki.json
-jmh_wyniki/
+jmh_wyniki/*
+!jmh_wyniki/.gitkeep

--- a/cinema-backend/build.gradle
+++ b/cinema-backend/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 
     testImplementation 'org.openjdk.jmh:jmh-core:1.33'
     testAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.33'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     implementation "org.mapstruct:mapstruct:${mapstructVer}"
     annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVer}"

--- a/cinema-backend/src/main/java/pl/edu/pw/ee/cinemabackend/config/selenium/SeleniumWebDriverConfig.java
+++ b/cinema-backend/src/main/java/pl/edu/pw/ee/cinemabackend/config/selenium/SeleniumWebDriverConfig.java
@@ -1,8 +1,6 @@
 package pl.edu.pw.ee.cinemabackend.config.selenium;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
-import org.openqa.selenium.JavascriptException;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -18,7 +16,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 @Configuration
-public class WebDriverConfig {
+public class SeleniumWebDriverConfig {
 
     @Value("chrome,firefox,edge,opera,safari")
     private List<String> browsers;

--- a/cinema-backend/src/main/java/pl/edu/pw/ee/cinemabackend/config/selenium/SeleniumWebDriverConfig.java
+++ b/cinema-backend/src/main/java/pl/edu/pw/ee/cinemabackend/config/selenium/SeleniumWebDriverConfig.java
@@ -53,9 +53,12 @@ public class SeleniumWebDriverConfig {
             default -> {
                 WebDriverManager.firefoxdriver()
                         .setup();
-                yield new FirefoxDriver(new FirefoxOptions() {{
-                    setBinary(Path.of("/usr/bin/firefox"));
-                }});
+                if(String.valueOf(System.getProperty("os.name")).toLowerCase().contains("linux")) {
+                    yield new FirefoxDriver(new FirefoxOptions() {{
+                        setBinary(Path.of("/usr/bin/firefox"));
+                    }});
+                }
+                yield new FirefoxDriver();
             }
         };
         driver.manage()

--- a/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/HomePageSeleniumTests.java
+++ b/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/HomePageSeleniumTests.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import pl.edu.pw.ee.cinemabackend.config.selenium.WebDriverConfig;
+import pl.edu.pw.ee.cinemabackend.config.selenium.SeleniumWebDriverConfig;
 import pl.edu.pw.ee.cinemabackend.pages.HomePage;
 import pl.edu.pw.ee.cinemabackend.pages.LoginPage;
 
@@ -30,13 +30,13 @@ class HomePageSeleniumTests {
     @Value("${browser}")
     private String browser;
     @Autowired
-    private WebDriverConfig webDriverConfig;
+    private SeleniumWebDriverConfig seleniumWebDriverConfig;
     private HomePage homePage;
     private WebDriver driver;
 
     @BeforeEach
     final void setup() {
-        driver = webDriverConfig.setUpWebDriver(browser);
+        driver = seleniumWebDriverConfig.setUpWebDriver(browser);
         driver.get(LOGIN_URL);
         LoginPage loginPage = new LoginPage(driver);
         signIn(loginPage);

--- a/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/LoginPageSeleniumTests.java
+++ b/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/LoginPageSeleniumTests.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import pl.edu.pw.ee.cinemabackend.config.selenium.WebDriverConfig;
+import pl.edu.pw.ee.cinemabackend.config.selenium.SeleniumWebDriverConfig;
 import pl.edu.pw.ee.cinemabackend.pages.LoginPage;
 
 import java.time.Duration;
@@ -29,13 +29,13 @@ class LoginPageSeleniumTests {
     @Value("${browser}")
     private String browser;
     @Autowired
-    private WebDriverConfig webDriverConfig;
+    private SeleniumWebDriverConfig seleniumWebDriverConfig;
     private LoginPage loginPage;
     private WebDriver driver;
 
     @BeforeEach
     final void setup() {
-        driver = webDriverConfig.setUpWebDriver(browser);
+        driver = seleniumWebDriverConfig.setUpWebDriver(browser);
         driver.get(LOGIN_URL);
         loginPage = new LoginPage(driver);
     }

--- a/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/MovieDetailsSeleniumTests.java
+++ b/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/MovieDetailsSeleniumTests.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import pl.edu.pw.ee.cinemabackend.config.selenium.WebDriverConfig;
+import pl.edu.pw.ee.cinemabackend.config.selenium.SeleniumWebDriverConfig;
 import pl.edu.pw.ee.cinemabackend.pages.LoginPage;
 import pl.edu.pw.ee.cinemabackend.pages.MovieDetailsPage;
 
@@ -30,13 +30,13 @@ class MovieDetailsSeleniumTests {
     @Value("${browser}")
     private String browser;
     @Autowired
-    private WebDriverConfig webDriverConfig;
+    private SeleniumWebDriverConfig seleniumWebDriverConfig;
     private MovieDetailsPage movieDetailsPage;
     private WebDriver driver;
 
     @BeforeEach
     final void setup() {
-        driver = webDriverConfig.setUpWebDriver(browser);
+        driver = seleniumWebDriverConfig.setUpWebDriver(browser);
         driver.get(LOGIN_URL);
         LoginPage loginPage = new LoginPage(driver);
         signIn(loginPage);

--- a/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/MoviesPageSeleniumTests.java
+++ b/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/MoviesPageSeleniumTests.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import pl.edu.pw.ee.cinemabackend.config.selenium.WebDriverConfig;
+import pl.edu.pw.ee.cinemabackend.config.selenium.SeleniumWebDriverConfig;
 import pl.edu.pw.ee.cinemabackend.pages.LoginPage;
 import pl.edu.pw.ee.cinemabackend.pages.MoviesPage;
 
@@ -34,14 +34,14 @@ class MoviesPageSeleniumTests {
     @Value("${browser}")
     private String browser;
     @Autowired
-    private WebDriverConfig webDriverConfig;
+    private SeleniumWebDriverConfig seleniumWebDriverConfig;
     private MoviesPage moviesPage;
     private WebDriver driver;
     private final Pattern pattern = Pattern.compile("\\d+");
 
     @BeforeEach
     final void setup() {
-        driver = webDriverConfig.setUpWebDriver(browser);
+        driver = seleniumWebDriverConfig.setUpWebDriver(browser);
         driver.get(LOGIN_URL);
         LoginPage loginPage = new LoginPage(driver);
         signIn(loginPage);

--- a/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/RegisterPageSeleniumTests.java
+++ b/cinema-backend/src/test/java/pl/edu/pw/ee/cinemabackend/selenium/RegisterPageSeleniumTests.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import pl.edu.pw.ee.cinemabackend.config.selenium.WebDriverConfig;
+import pl.edu.pw.ee.cinemabackend.config.selenium.SeleniumWebDriverConfig;
 import pl.edu.pw.ee.cinemabackend.pages.RegisterPage;
 
 import java.time.Duration;
@@ -29,13 +29,13 @@ class RegisterPageSeleniumTests {
     @Value("${browser}")
     private String browser;
     @Autowired
-    private WebDriverConfig webDriverConfig;
+    private SeleniumWebDriverConfig seleniumWebDriverConfig;
     private RegisterPage registerPage;
     private WebDriver driver;
 
     @BeforeEach
     final void setup() {
-        driver = webDriverConfig.setUpWebDriver(browser);
+        driver = seleniumWebDriverConfig.setUpWebDriver(browser);
         driver.get(REGISTER_URL);
         registerPage = new RegisterPage(driver);
     }

--- a/cinema-frontend/cypress.config.ts
+++ b/cinema-frontend/cypress.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+});

--- a/cinema-frontend/cypress/e2e/pages/home.ts
+++ b/cinema-frontend/cypress/e2e/pages/home.ts
@@ -1,0 +1,17 @@
+import { findButtonByTextIn } from "../util";
+
+export function getToolbar() {
+    return cy.get('APP-NAV>MAT-TOOLBAR>MAT-TOOLBAR-ROW');
+}
+
+export function getMoviesButton() {
+    return getToolbar().get('DIV:nth-child(2)>BUTTON:nth-child(2)');
+}
+
+export function getHomeButton() {
+    return getToolbar().get('DIV:nth-child(2)>BUTTON:nth-child(1)');
+}
+
+export function getLogoutButton() {
+    return findButtonByTextIn(getToolbar(), "logout");
+}

--- a/cinema-frontend/cypress/e2e/pages/login.cy.ts
+++ b/cinema-frontend/cypress/e2e/pages/login.cy.ts
@@ -1,0 +1,103 @@
+import { findButtonByText } from "../util";
+
+describe('Login Page', () => {
+
+    beforeEach(() => {
+        cy.visit('http://localhost:4200/auth/login')
+    })
+
+    it('should display login form', () => {
+        getForm().should('be.visible');
+    })
+
+    it('should have correct title', () => {
+        cy.title().should('eq', 'CinemaFrontend');
+    })
+
+    it(': Register button should redirect to register page', () => {
+        findButtonByText("register").click();
+
+        cy.url().should('eq', 'http://localhost:4200/auth/register');
+    })
+
+    it(': After clicking on and out of empty input fields, the errors should be displayed', () => {
+        getEmailInputError().should('not.exist');
+        getEmailInput().click();
+        getForm().click();
+        getEmailInputError().should('exist');
+        
+        getPasswordInputError().should('not.exist');
+        getPasswordInput().click();
+        getForm().click();
+        getPasswordInputError().should('exist');
+    })
+
+    it(': After clicking on and out of empty input fields, the errors should be displayed', () => {
+        getEmailInputError().should('not.exist');
+        getEmailInput().click();
+        getForm().click();
+        getEmailInputError().should('exist');
+        
+        getPasswordInputError().should('not.exist');
+        getPasswordInput().click();
+        getForm().click();
+        getPasswordInputError().should('exist');
+    })
+
+    it(': After entering garbage data into input fields, the errors should be displayed', () => {
+        getEmailInputError().should('not.exist');
+        getEmailInput().type("abc");
+        getForm().click();
+        getEmailInputError().should('exist');
+        
+        getPasswordInputError().should('not.exist');
+        getPasswordInput().type("abc");
+        getForm().click();
+        getPasswordInputError().should('exist');
+    })
+
+    it(': After entering correct data into input fields, the errors should NOT be displayed', () => {
+        getEmailInputError().should('not.exist');
+        getEmailInput().type("valid@email.address");
+        getForm().click();
+        getEmailInputError().should('not.exist');
+        
+        getPasswordInputError().should('not.exist');
+        getPasswordInput().type("kicia.?312312312As");
+        getForm().click();
+        getPasswordInputError().should('not.exist');
+    })
+
+    it(': After entering correct credentials and clicking Login button, we should be logged in and redirected to home', () => {
+        getEmailInput().type("user123@mail.pl");
+        getPasswordInput().type("user");
+        findButtonByText("login").click();
+        cy.url().should('eq', 'http://localhost:4200/home');
+    })
+
+    it(': After entering INcorrect credentials and clicking Login button, we should stay at login page', () => {
+        getEmailInput().type("user123@mail.pl");
+        getPasswordInput().type("badpassword");
+        findButtonByText("login").click();
+        cy.url().should('eq', 'http://localhost:4200/auth/login');
+    })
+
+    function getForm() {
+        return cy.get('APP-LOGIN').get('FORM');
+    }
+
+    function getEmailInput() {
+        return getForm().get('APP-EMAIL-FIELD:nth-child(2)>MAT-FORM-FIELD>DIV>DIV:nth-child(2)>DIV>INPUT:nth-child(2)');
+    }
+    function getEmailInputError() {
+        return getForm().get('APP-EMAIL-FIELD:nth-child(2)>MAT-FORM-FIELD>DIV:nth-child(2)>DIV>MAT-ERROR');
+    }
+
+    function getPasswordInput() {
+        return getForm().get('APP-PASSWORD-FIELD:nth-child(3)>MAT-FORM-FIELD>DIV>DIV:nth-child(2)>DIV>INPUT:nth-child(2)');
+    }
+    function getPasswordInputError() {
+        return getForm().get('APP-PASSWORD-FIELD:nth-child(3)>MAT-FORM-FIELD>DIV:nth-child(2)>DIV>MAT-ERROR');
+    }
+
+})

--- a/cinema-frontend/cypress/e2e/pages/login.ts
+++ b/cinema-frontend/cypress/e2e/pages/login.ts
@@ -1,0 +1,43 @@
+import { findButtonByTextIn } from "../util";
+
+export function getForm() {
+    return cy.get('APP-LOGIN').get('FORM');
+}
+
+export function getEmailInput() {
+    return getForm().get('APP-EMAIL-FIELD:nth-child(2)>MAT-FORM-FIELD>DIV>DIV:nth-child(2)>DIV>INPUT:nth-child(2)');
+}
+
+export function getEmailInputError() {
+    return getForm().get('APP-EMAIL-FIELD:nth-child(2)>MAT-FORM-FIELD>DIV:nth-child(2)>DIV>MAT-ERROR');
+}
+
+export function getPasswordInput() {
+    return getForm().get('APP-PASSWORD-FIELD:nth-child(3)>MAT-FORM-FIELD>DIV>DIV:nth-child(2)>DIV>INPUT:nth-child(2)');
+}
+
+export function getPasswordInputError() {
+    return getForm().get('APP-PASSWORD-FIELD:nth-child(3)>MAT-FORM-FIELD>DIV:nth-child(2)>DIV>MAT-ERROR');
+}
+
+export function getRegisterButton() {
+    return findButtonByTextIn(getForm(), "register");
+}
+
+export function getLoginButton() {
+    return findButtonByTextIn(getForm(), "login");
+}
+
+export function loginAsUser() {
+    cy.visit('http://localhost:4200/auth/login')
+    getEmailInput().type("user123@mail.pl");
+    getPasswordInput().type("user");
+    getLoginButton().click();
+}
+
+export function loginAsAdmin() {
+    cy.visit('http://localhost:4200/auth/login')
+    getEmailInput().type("admin123@mail.pl");
+    getPasswordInput().type("admin");
+    getLoginButton().click();
+}

--- a/cinema-frontend/cypress/e2e/pages/movie_details.ts
+++ b/cinema-frontend/cypress/e2e/pages/movie_details.ts
@@ -1,0 +1,13 @@
+import { findButtonByText, findButtonByTextIn } from "../util";
+
+export function getScreeningsList() {
+    return cy.get('APP-NAV:nth-child(2)>DIV:nth-child(2)>APP-MOVIE-DETAILS:nth-child(2)>DIV:nth-child(1)>DIV:nth-child(2)');
+}
+
+export function getReturnButton() {
+    return findButtonByText("return");
+}
+
+export function getAddButton() {
+    return findButtonByTextIn(getScreeningsList(), "add");
+}

--- a/cinema-frontend/cypress/e2e/pages/movies.ts
+++ b/cinema-frontend/cypress/e2e/pages/movies.ts
@@ -1,0 +1,37 @@
+import { findButtonByTextIn } from "../util";
+
+export function getTableBody() {
+    return cy.get('APP-NAV:nth-child(2)>DIV:nth-child(2)>APP-MOVIELIST:nth-child(2)>DIV:nth-child(1)>DIV:nth-child(1)>TABLE:nth-child(1)>TBODY:nth-child(2)');
+}
+
+export function getMoviesCalendar() {
+    return cy.get('APP-NAV:nth-child(2)>DIV:nth-child(2)>APP-MOVIELIST:nth-child(2)>DIV:nth-child(1)>DIV:nth-child(2)>MAT-CARD:nth-child(1)>MAT-CALENDAR:nth-child(1)');
+}
+
+export function getPageSizeSelector() {
+    return cy.get('APP-NAV:nth-child(2)>DIV:nth-child(2)>APP-MOVIELIST:nth-child(2)>DIV:nth-child(1)>DIV:nth-child(1)>MAT-PAGINATOR:nth-child(2)>DIV:nth-child(1)>DIV:nth-child(1)>DIV:nth-child(1)>MAT-FORM-FIELD:nth-child(2)>DIV:nth-child(1)>DIV:nth-child(1)>DIV:nth-child(2)>MAT-SELECT:nth-child(1)');
+}
+
+export function getSelectedPageSize(option: number) {
+    return cy.get(`HTML>BODY:nth-child(2)>DIV:nth-child(8)>DIV:nth-child(2)>DIV:nth-child(1)>DIV:nth-child(1)>MAT-OPTION:nth-child(${option})`);
+}
+
+export function getYearSelector() {
+    return getMoviesCalendar().get('MAT-CALENDAR-HEADER:nth-child(1)>DIV:nth-child(1)>DIV:nth-child(1)>BUTTON:nth-child(1)');
+}
+
+export function getDaySelectorTable() {
+    return getMoviesCalendar().get('DIV:nth-child(2)>MAT-MONTH-VIEW:nth-child(1)>TABLE:nth-child(1)>TBODY:nth-child(2)');
+}
+
+export function getDayButton(day: number) {
+    return findButtonByTextIn(getDaySelectorTable(), ""+day);
+}
+
+export function getFirstYearInYearSelector() {
+    return getMoviesCalendar().get('DIV:nth-child(2)>MAT-MULTI-YEAR-VIEW:nth-child(1)>TABLE:nth-child(1)>TBODY:nth-child(2)>TR:nth-child(1)>TD:nth-child(1)>BUTTON:nth-child(1)');
+}
+
+export function getJanuaryInMonthSelector() {
+    return getMoviesCalendar().get('DIV:nth-child(2)>MAT-YEAR-VIEW:nth-child(1)>TABLE:nth-child(1)>TBODY:nth-child(2)>TR:nth-child(2)>TD:nth-child(1)>BUTTON:nth-child(1)');
+}

--- a/cinema-frontend/cypress/e2e/pages/movies.ts
+++ b/cinema-frontend/cypress/e2e/pages/movies.ts
@@ -13,7 +13,7 @@ export function getPageSizeSelector() {
 }
 
 export function getSelectedPageSize(option: number) {
-    return cy.get(`HTML>BODY:nth-child(2)>DIV:nth-child(8)>DIV:nth-child(2)>DIV:nth-child(1)>DIV:nth-child(1)>MAT-OPTION:nth-child(${option})`);
+    return cy.get(`HTML>BODY:nth-child(2)>DIV>DIV:nth-child(2)>DIV:nth-child(1)>DIV:nth-child(1)>MAT-OPTION:nth-child(${option})`);
 }
 
 export function getYearSelector() {

--- a/cinema-frontend/cypress/e2e/pages/register.ts
+++ b/cinema-frontend/cypress/e2e/pages/register.ts
@@ -1,0 +1,45 @@
+import { findButtonByTextIn } from "../util";
+
+export function getForm() {
+    return cy.get('APP-REGISTER').get('FORM');
+}
+
+export function getNameInput() {
+    return getForm().get('DIV:nth-child(2)>APP-NAME-FIELD:nth-child(1)>MAT-FORM-FIELD:nth-child(1)>DIV:nth-child(1)>DIV:nth-child(2)>DIV:nth-child(1)>INPUT:nth-child(2)');
+}
+
+export function getSurnameInput() {
+    return getForm().get('DIV:nth-child(2)>APP-NAME-FIELD:nth-child(2)>MAT-FORM-FIELD:nth-child(1)>DIV:nth-child(1)>DIV:nth-child(2)>DIV:nth-child(1)>INPUT:nth-child(2)');
+}
+
+export function getEmailInput() {
+    return getForm().get('APP-EMAIL-FIELD:nth-child(3)>MAT-FORM-FIELD>DIV>DIV:nth-child(2)>DIV>INPUT:nth-child(2)');
+}
+
+export function getEmailInputError() {
+    return getForm().get('APP-EMAIL-FIELD:nth-child(3)>MAT-FORM-FIELD>DIV:nth-child(2)>DIV>MAT-ERROR');
+}
+
+export function getPasswordInput() {
+    return getForm().get('DIV:nth-child(4)>APP-PASSWORD-FIELD:nth-child(1)>MAT-FORM-FIELD:nth-child(1)>DIV:nth-child(1)>DIV:nth-child(2)>DIV:nth-child(1)>INPUT:nth-child(2)');
+}
+
+export function getPasswordInputError() {
+    return getForm().get('DIV:nth-child(4)>APP-PASSWORD-FIELD:nth-child(1)>MAT-FORM-FIELD>DIV:nth-child(2)>DIV>MAT-ERROR');
+}
+
+export function getRepeatPasswordInput() {
+    return getForm().get('DIV:nth-child(4)>APP-PASSWORD-FIELD:nth-child(2)>MAT-FORM-FIELD:nth-child(1)>DIV:nth-child(1)>DIV:nth-child(2)>DIV:nth-child(1)>INPUT:nth-child(2)');
+}
+
+export function getRepeatPasswordInputError() {
+    return getForm().get('DIV:nth-child(4)>APP-PASSWORD-FIELD:nth-child(2)>MAT-FORM-FIELD>DIV:nth-child(2)>DIV>MAT-ERROR');
+}
+
+export function getRegisterButton() {
+    return findButtonByTextIn(getForm(), "register");
+}
+
+export function getReturn() {
+    return findButtonByTextIn(getForm(), "return");
+}

--- a/cinema-frontend/cypress/e2e/tests/home.cy.ts
+++ b/cinema-frontend/cypress/e2e/tests/home.cy.ts
@@ -1,0 +1,30 @@
+import { getHomeButton, getLogoutButton, getMoviesButton } from "../pages/home";
+import { loginAsUser } from "../pages/login";
+import { findButtonByText } from "../util";
+
+describe('Home Page', () => {
+    
+    beforeEach(() => {
+        loginAsUser();
+    })
+
+    it(': After login we should be at home page', () => {
+        cy.url().should('eq', 'http://localhost:4200/home');
+    })
+
+    it(': We should be redirected to login page after clicking Logout button', () => {
+        getLogoutButton().click();
+        cy.url().should('eq', 'http://localhost:4200/auth/login');
+    })
+
+    it(': We should be redirected to movies page after clicking Movies button', () => {
+        getMoviesButton().click();
+        cy.url().should('eq', 'http://localhost:4200/home/movies');
+    })
+
+    it(': We should stay at home page after clicking Home button', () => {
+        getHomeButton().click();
+        cy.url().should('eq', 'http://localhost:4200/home');
+    })
+
+})

--- a/cinema-frontend/cypress/e2e/tests/home.cy.ts
+++ b/cinema-frontend/cypress/e2e/tests/home.cy.ts
@@ -1,6 +1,5 @@
 import { getHomeButton, getLogoutButton, getMoviesButton } from "../pages/home";
 import { loginAsUser } from "../pages/login";
-import { findButtonByText } from "../util";
 
 describe('Home Page', () => {
     

--- a/cinema-frontend/cypress/e2e/tests/login.cy.ts
+++ b/cinema-frontend/cypress/e2e/tests/login.cy.ts
@@ -1,4 +1,4 @@
-import { findButtonByText } from "../util";
+import { getEmailInput, getEmailInputError, getForm, getLoginButton, getPasswordInput, getPasswordInputError, getRegisterButton } from "../pages/login";
 
 describe('Login Page', () => {
 
@@ -15,8 +15,7 @@ describe('Login Page', () => {
     })
 
     it(': Register button should redirect to register page', () => {
-        findButtonByText("register").click();
-
+        getRegisterButton().click();
         cy.url().should('eq', 'http://localhost:4200/auth/register');
     })
 
@@ -71,33 +70,15 @@ describe('Login Page', () => {
     it(': After entering correct credentials and clicking Login button, we should be logged in and redirected to home', () => {
         getEmailInput().type("user123@mail.pl");
         getPasswordInput().type("user");
-        findButtonByText("login").click();
+        getLoginButton().click();
         cy.url().should('eq', 'http://localhost:4200/home');
     })
 
     it(': After entering INcorrect credentials and clicking Login button, we should stay at login page', () => {
         getEmailInput().type("user123@mail.pl");
         getPasswordInput().type("badpassword");
-        findButtonByText("login").click();
+        getLoginButton().click();
         cy.url().should('eq', 'http://localhost:4200/auth/login');
     })
-
-    function getForm() {
-        return cy.get('APP-LOGIN').get('FORM');
-    }
-
-    function getEmailInput() {
-        return getForm().get('APP-EMAIL-FIELD:nth-child(2)>MAT-FORM-FIELD>DIV>DIV:nth-child(2)>DIV>INPUT:nth-child(2)');
-    }
-    function getEmailInputError() {
-        return getForm().get('APP-EMAIL-FIELD:nth-child(2)>MAT-FORM-FIELD>DIV:nth-child(2)>DIV>MAT-ERROR');
-    }
-
-    function getPasswordInput() {
-        return getForm().get('APP-PASSWORD-FIELD:nth-child(3)>MAT-FORM-FIELD>DIV>DIV:nth-child(2)>DIV>INPUT:nth-child(2)');
-    }
-    function getPasswordInputError() {
-        return getForm().get('APP-PASSWORD-FIELD:nth-child(3)>MAT-FORM-FIELD>DIV:nth-child(2)>DIV>MAT-ERROR');
-    }
 
 })

--- a/cinema-frontend/cypress/e2e/tests/login.cy.ts
+++ b/cinema-frontend/cypress/e2e/tests/login.cy.ts
@@ -31,18 +31,6 @@ describe('Login Page', () => {
         getPasswordInputError().should('exist');
     })
 
-    it(': After clicking on and out of empty input fields, the errors should be displayed', () => {
-        getEmailInputError().should('not.exist');
-        getEmailInput().click();
-        getForm().click();
-        getEmailInputError().should('exist');
-        
-        getPasswordInputError().should('not.exist');
-        getPasswordInput().click();
-        getForm().click();
-        getPasswordInputError().should('exist');
-    })
-
     it(': After entering garbage data into input fields, the errors should be displayed', () => {
         getEmailInputError().should('not.exist');
         getEmailInput().type("abc");

--- a/cinema-frontend/cypress/e2e/tests/movie_details.cy.ts
+++ b/cinema-frontend/cypress/e2e/tests/movie_details.cy.ts
@@ -1,0 +1,43 @@
+import { loginAsAdmin, loginAsUser } from "../pages/login";
+import { getAddButton, getReturnButton, getScreeningsList } from "../pages/movie_details";
+
+describe('Home Page', () => {
+
+    it(': Return button should redirect to movies page', () => {
+        loginAsUser();
+        cy.url().should('eq', 'http://localhost:4200/home');
+        cy.visit('http://localhost:4200/home/movie_details?id=3');
+        getReturnButton().click()
+        cy.url().should('eq', 'http://localhost:4200/home/movies');
+    })
+
+    it(': User should NOT see screenings adding tab', () => {
+        loginAsUser();
+        cy.url().should('eq', 'http://localhost:4200/home');
+        cy.visit('http://localhost:4200/home/movie_details?id=3');
+        getAddButton().should('not.be.visible');
+    })
+
+    it(': Admin should not see screenings adding tab', () => {
+        loginAsAdmin();
+        cy.url().should('eq', 'http://localhost:4200/home');
+        cy.visit('http://localhost:4200/home/movie_details?id=3');
+        getAddButton().should('be.visible');
+    })
+
+    it(': When admin add a screening, the screening list size should increase', () => {
+        loginAsAdmin();
+        cy.url().should('eq', 'http://localhost:4200/home');
+        cy.visit('http://localhost:4200/home/movie_details?id=3');
+        cy.wait(800);
+        getScreeningsList().invoke('children').then((children) => {
+            const initialSize = children.length;
+            getAddButton().click();
+            cy.wait(800);
+            getScreeningsList().invoke('children').then((newchildren) => {
+                expect(newchildren.length).eq(initialSize + 1);
+            })
+        })
+    })
+
+})

--- a/cinema-frontend/cypress/e2e/tests/movies.cy.ts
+++ b/cinema-frontend/cypress/e2e/tests/movies.cy.ts
@@ -1,0 +1,43 @@
+import { getHomeButton, getLogoutButton, getMoviesButton } from "../pages/home";
+import { loginAsUser } from "../pages/login";
+import { getDayButton, getFirstYearInYearSelector, getJanuaryInMonthSelector, getPageSizeSelector, getSelectedPageSize as getSelectedPageSizeOption, getTableBody, getYearSelector } from "../pages/movies";
+
+describe('Home Page', () => {
+    
+    beforeEach(() => {
+        loginAsUser();
+        getMoviesButton().click();
+    })
+
+    it(': After start we should be at movies page', () => {
+        cy.url().should('eq', 'http://localhost:4200/home/movies');
+    })
+
+    it(': Today should be full list of movies', () => {
+        getTableBody().invoke('children').then((children) => {
+            expect(children.length).eq(5)
+        })
+    })
+
+    it(': Table length should increse when increasing page size', () => {
+        getTableBody().invoke('children').then((children) => {
+            const initialLength = children.length;
+            getPageSizeSelector().click();
+            getSelectedPageSizeOption(2).click();
+            getTableBody().invoke('children').then((newchildren) => {
+                expect(newchildren.length).gt(initialLength)
+            })
+        })
+    })
+
+    it(': The should be no movies in the past', () => {
+        getYearSelector().click();
+        getFirstYearInYearSelector().click();
+        getJanuaryInMonthSelector().click();
+        getDayButton(13).click();
+        getTableBody().invoke('children').then((children) => {
+            expect(children.length).eq(0)
+        })
+    })
+
+})

--- a/cinema-frontend/cypress/e2e/tests/register.cy.ts
+++ b/cinema-frontend/cypress/e2e/tests/register.cy.ts
@@ -1,0 +1,106 @@
+import { getEmailInput, getEmailInputError, getForm, getNameInput, getPasswordInput, getPasswordInputError, getRegisterButton, getRepeatPasswordInput, getRepeatPasswordInputError, getReturn, getSurnameInput } from "../pages/register";
+import { generateRandomEmail } from "../util";
+
+describe('Register Page', () => {
+
+    beforeEach(() => {
+        cy.visit('http://localhost:4200/auth/register')
+    })
+
+    it('should display register form', () => {
+        getForm().should('be.visible');
+    })
+
+    it('should have correct title', () => {
+        cy.title().should('eq', 'CinemaFrontend');
+    })
+
+    it(': Return button should redirect to login page', () => {
+        getReturn().click();
+        cy.url().should('eq', 'http://localhost:4200/auth/login');
+    })
+
+    it(': After clicking on and out of empty input fields, the errors should be displayed', () => {
+        getEmailInputError().should('not.exist');
+        getEmailInput().click();
+        getForm().click();
+        getEmailInputError().invoke('text').then((text) => {
+            expect(text.trim()).to.equal('Email is required')
+        })
+
+        getPasswordInputError().should('not.exist');
+        getPasswordInput().click();
+        getForm().click();
+        getPasswordInputError().invoke('text').then((text) => {
+            expect(text.trim()).to.equal('Password is required')
+        })
+
+        getRepeatPasswordInputError().should('not.exist');
+        getRepeatPasswordInput().click();
+        getForm().click();
+        getRepeatPasswordInputError().invoke('text').then((text) => {
+            expect(text.trim()).to.equal('Password is required')
+        })
+    })
+
+    it(': After entering garbage data into input fields, the errors should be displayed', () => {
+        getEmailInputError().should('not.exist');
+        getEmailInput().type("abc");
+        getForm().click();
+        getEmailInputError().invoke('text').then((text) => {
+            expect(text.trim()).to.equal('Please enter a valid email address')
+        })
+
+        getPasswordInputError().should('not.exist');
+        getPasswordInput().type("abc");
+        getForm().click();
+        getPasswordInputError().invoke('text').then((text) => {
+            expect(text.trim()).to.equal('Please enter a valid password address')
+        })
+
+        getRepeatPasswordInputError().should('not.exist');
+        getRepeatPasswordInput().type("abc");
+        getForm().click();
+        getRepeatPasswordInputError().invoke('text').then((text) => {
+            expect(text.trim()).to.equal('Please enter a valid password address')
+        })
+    })
+
+    it(': After entering correct data into input fields, the errors should NOT be displayed', () => {
+        getEmailInputError().should('not.exist');
+        getEmailInput().type("valid@email.address");
+        getForm().click();
+        getEmailInputError().should('not.exist');
+
+        getPasswordInputError().should('not.exist');
+        getPasswordInput().type("kicia.?312312312As");
+        getForm().click();
+        getPasswordInputError().should('not.exist');
+
+        getRepeatPasswordInputError().should('not.exist');
+        getRepeatPasswordInput().type("kicia.?312312312As");
+        getForm().click();
+        getRepeatPasswordInputError().should('not.exist');
+    })
+
+    it(': After entering correct credentials and clicking Register button, we should be registered and redirected to home', () => {
+        getNameInput().type("aaa");
+        getSurnameInput().type("aaa");
+        getEmailInput().type(generateRandomEmail());
+        getPasswordInput().type("kicia.?312312312As");
+        getRepeatPasswordInput().type("kicia.?312312312As");
+        getRegisterButton().click();
+        cy.url().should('eq', 'http://localhost:4200/home');
+    })
+
+    it(': After entering INcorrect credentials and clicking Register button, we should stay at register page', () => {
+        getNameInput().type("aaa");
+        getSurnameInput().type("aaa");
+        getEmailInput().type("valid@email.address");
+        getPasswordInput().type("kicia.?312312312Ab");
+        getRepeatPasswordInput().type("kicia.?312312312As");
+        getRegisterButton().click();
+        cy.url().should('eq', 'http://localhost:4200/auth/register');
+    })
+
+})

--- a/cinema-frontend/cypress/e2e/util.ts
+++ b/cinema-frontend/cypress/e2e/util.ts
@@ -1,3 +1,6 @@
 export function findButtonByText(buttonText: any) {
     return cy.contains('button', buttonText, { matchCase: false });
 }
+export function findButtonByTextIn(ctx: any, buttonText: any) {
+    return ctx.contains('button', buttonText, { matchCase: false });
+}

--- a/cinema-frontend/cypress/e2e/util.ts
+++ b/cinema-frontend/cypress/e2e/util.ts
@@ -1,0 +1,3 @@
+export function findButtonByText(buttonText: any) {
+    return cy.contains('button', buttonText, { matchCase: false });
+}

--- a/cinema-frontend/cypress/e2e/util.ts
+++ b/cinema-frontend/cypress/e2e/util.ts
@@ -4,3 +4,9 @@ export function findButtonByText(buttonText: any) {
 export function findButtonByTextIn(ctx: any, buttonText: any) {
     return ctx.contains('button', buttonText, { matchCase: false });
 }
+export function generateRandomEmail() {
+    const username = Math.random().toString(36).substring(2, 10);
+    const domain = Math.random().toString(36).substring(2, 8);
+    const email = `x${username}@x${domain}.com`;
+    return email;
+}

--- a/cinema-frontend/cypress/fixtures/example.json
+++ b/cinema-frontend/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cinema-frontend/cypress/support/commands.ts
+++ b/cinema-frontend/cypress/support/commands.ts
@@ -1,0 +1,37 @@
+/// <reference types="cypress" />
+// ***********************************************
+// This example commands.ts shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+//
+// declare global {
+//   namespace Cypress {
+//     interface Chainable {
+//       login(email: string, password: string): Chainable<void>
+//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
+//     }
+//   }
+// }

--- a/cinema-frontend/cypress/support/e2e.ts
+++ b/cinema-frontend/cypress/support/e2e.ts
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/e2e.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/cinema-frontend/how-to-run-cypress.txt
+++ b/cinema-frontend/how-to-run-cypress.txt
@@ -1,0 +1,6 @@
+npm install
+npx cypress open
+>E2E Testing
+>Electron
+>Start E2E Testing in Electron
+>*select some spec and run it*

--- a/cinema-frontend/package-lock.json
+++ b/cinema-frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@angular/cli": "^16.2.6",
         "@angular/compiler-cli": "^16.2.0",
         "@types/jasmine": "~4.3.0",
+        "cypress": "^13.6.1",
         "jasmine-core": "~4.6.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -2472,6 +2473,83 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@cypress/request": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
+      "dev": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "http-signature": "~1.3.6",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "performance-now": "^2.1.0",
+        "qs": "6.10.4",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "^4.1.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/qs": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
+      "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@cypress/xvfb": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
+      "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.1.0",
+        "lodash.once": "^4.1.1"
+      }
+    },
+    "node_modules/@cypress/xvfb/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -4412,6 +4490,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
+      "dev": true
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
+      "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
+      "dev": true
+    },
     "node_modules/@types/sockjs": {
       "version": "0.3.36",
       "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
@@ -4426,6 +4516,16 @@
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
       "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
       "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4962,6 +5062,26 @@
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true
     },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
@@ -4990,11 +5110,53 @@
       "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
       "dev": true
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+      "dev": true
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.14",
@@ -5028,6 +5190,21 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+      "dev": true
     },
     "node_modules/babel-loader": {
       "version": "9.1.3",
@@ -5151,6 +5328,15 @@
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -5179,6 +5365,18 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/blob-util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
+      "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==",
+      "dev": true
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -5321,6 +5519,15 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5432,6 +5639,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
@@ -5484,6 +5700,12 @@
         }
       ]
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -5503,6 +5725,15 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/check-more-types": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -5549,6 +5780,21 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -5577,6 +5823,37 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
+      "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5681,6 +5958,15 @@
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
       "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
       "dev": true
+    },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -6169,6 +6455,274 @@
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
     },
+    "node_modules/cypress": {
+      "version": "13.6.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.1.tgz",
+      "integrity": "sha512-k1Wl5PQcA/4UoTffYKKaxA0FJKwg8yenYNYRzLt11CUR0Kln+h7Udne6mdU1cUIdXBDTVZWtmiUjzqGs7/pEpw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@cypress/request": "^3.0.0",
+        "@cypress/xvfb": "^1.2.4",
+        "@types/node": "^18.17.5",
+        "@types/sinonjs__fake-timers": "8.1.1",
+        "@types/sizzle": "^2.3.2",
+        "arch": "^2.2.0",
+        "blob-util": "^2.0.2",
+        "bluebird": "^3.7.2",
+        "buffer": "^5.6.0",
+        "cachedir": "^2.3.0",
+        "chalk": "^4.1.0",
+        "check-more-types": "^2.24.0",
+        "cli-cursor": "^3.1.0",
+        "cli-table3": "~0.6.1",
+        "commander": "^6.2.1",
+        "common-tags": "^1.8.0",
+        "dayjs": "^1.10.4",
+        "debug": "^4.3.4",
+        "enquirer": "^2.3.6",
+        "eventemitter2": "6.4.7",
+        "execa": "4.1.0",
+        "executable": "^4.1.1",
+        "extract-zip": "2.0.1",
+        "figures": "^3.2.0",
+        "fs-extra": "^9.1.0",
+        "getos": "^3.2.1",
+        "is-ci": "^3.0.0",
+        "is-installed-globally": "~0.4.0",
+        "lazy-ass": "^1.6.0",
+        "listr2": "^3.8.3",
+        "lodash": "^4.17.21",
+        "log-symbols": "^4.0.0",
+        "minimist": "^1.2.8",
+        "ospath": "^1.2.2",
+        "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
+        "proxy-from-env": "1.0.0",
+        "request-progress": "^3.0.0",
+        "semver": "^7.5.3",
+        "supports-color": "^8.1.1",
+        "tmp": "~0.2.1",
+        "untildify": "^4.0.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "cypress": "bin/cypress"
+      },
+      "engines": {
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/cypress/node_modules/@types/node": {
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/cypress/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cypress/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cypress/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cypress/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cypress/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cypress/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cypress/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/cypress/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cypress/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cypress/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cypress/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/cypress/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/cypress/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/cypress/node_modules/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "dependencies": {
+        "rimraf": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0"
+      }
+    },
+    "node_modules/cypress/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -6191,6 +6745,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -6433,6 +6993,16 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6490,6 +7060,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/engine.io": {
@@ -6554,6 +7133,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/ent": {
@@ -6801,6 +7393,12 @@
       "integrity": "sha512-39F7TBIV0G7gTelxwbEqnwhp90eqCPON1k0NwNfwhgKn4Co4ybUbj2pECcXT0B3ztRKZ7Pw1JujUUgmQJHcVAQ==",
       "dev": true
     },
+    "node_modules/eventemitter2": {
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
+      "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
+      "dev": true
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -6837,6 +7435,27 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/executable": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+      "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/executable/node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -7003,6 +7622,50 @@
         "node": ">=4"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7050,6 +7713,15 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/figures": {
@@ -7205,6 +7877,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/form-data": {
@@ -7395,6 +8076,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/getos": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
+      "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.0"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -7432,6 +8131,30 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
+    },
+    "node_modules/global-dirs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+      "dev": true,
+      "dependencies": {
+        "ini": "2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-dirs/node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/globals": {
       "version": "11.12.0",
@@ -7788,6 +8511,20 @@
         }
       }
     },
+    "node_modules/http-signature": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+      "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^2.0.2",
+        "sshpk": "^1.14.1"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -8130,6 +8867,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
@@ -8187,6 +8936,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "dependencies": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -8209,6 +8974,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -8252,6 +9026,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -8315,6 +9095,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -8511,6 +9297,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "dev": true
+    },
     "node_modules/jsdom": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -8575,10 +9367,22 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
     "node_modules/json5": {
@@ -8616,6 +9420,21 @@
       "engines": [
         "node >= 0.2.0"
       ]
+    },
+    "node_modules/jsprim": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      }
     },
     "node_modules/karma": {
       "version": "6.4.2",
@@ -8803,6 +9622,15 @@
         "shell-quote": "^1.8.1"
       }
     },
+    "node_modules/lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
+      "dev": true,
+      "engines": {
+        "node": "> 0.8"
+      }
+    },
     "node_modules/less": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/less/-/less-4.1.3.tgz",
@@ -8919,6 +9747,33 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/listr2": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
+      "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.16",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.5.1",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
+      },
+      "peerDependenciesMeta": {
+        "enquirer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -8959,6 +9814,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
     "node_modules/log-symbols": {
@@ -9042,6 +9903,88 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-update/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -10369,6 +11312,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ospath": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
+      "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
+      "dev": true
+    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -10657,6 +11606,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -10933,6 +11894,15 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -10980,6 +11950,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
+      "dev": true
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -10992,6 +11968,16 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -11284,6 +12270,15 @@
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
+      }
+    },
+    "node_modules/request-progress": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+      "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
+      "dev": true,
+      "dependencies": {
+        "throttleit": "^1.0.0"
       }
     },
     "node_modules/require-directory": {
@@ -12022,6 +13017,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -12269,6 +13311,31 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "dev": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ssri": {
       "version": "10.0.5",
@@ -12614,6 +13681,15 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/throttleit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.1.tgz",
+      "integrity": "sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -12816,6 +13892,24 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true
+    },
     "node_modules/type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
@@ -12971,6 +14065,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -13074,6 +14177,26 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true
     },
     "node_modules/vite": {
       "version": "4.4.7",
@@ -13730,6 +14853,16 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/cinema-frontend/package.json
+++ b/cinema-frontend/package.json
@@ -30,6 +30,7 @@
     "@angular/cli": "^16.2.6",
     "@angular/compiler-cli": "^16.2.0",
     "@types/jasmine": "~4.3.0",
+    "cypress": "^13.6.1",
     "jasmine-core": "~4.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/cinema-frontend/tsconfig.json
+++ b/cinema-frontend/tsconfig.json
@@ -10,7 +10,6 @@
         "noPropertyAccessFromIndexSignature": true,
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true,
-        "sourceMap": true,
         "declaration": false,
         "downlevelIteration": true,
         "experimentalDecorators": true,


### PR DESCRIPTION
Przepisano większość testów z selenium na cypress i dodano kilka nowych testów. Potrzebny był też merge gałęzi naprawiającej testy w selenium i jmh, ale nie jest on konieczny do uruchomienia testów w cypressie